### PR TITLE
1-bug: void type specifier missing

### DIFF
--- a/1_CALC_MVC/view/clviewmodel.h
+++ b/1_CALC_MVC/view/clviewmodel.h
@@ -14,7 +14,7 @@ class CLViewModel: public QObject
     void eraseOne();
     int getDisplaySize();
   signals:
-    displayValueChanged(QString newValue);
+    void displayValueChanged(QString newValue);
   private:
     QString displayValue;
 };


### PR DESCRIPTION
- Fixed a bug where void type specifier was missing from a signal and the MinGW compiler somehow found it OK. Current MSVC compiler does not, so it was fixed.