### PR TITLE
2-bug: equals sign sequencing is broken

### DIFF
--- a/1_CALC_MVC/1_CALC_MVC.pro
+++ b/1_CALC_MVC/1_CALC_MVC.pro
@@ -43,6 +43,8 @@ HEADERS += \
     model/clmodeldata.h \
     model/cloperations.h \
     model/clmodel.h \
+    view/clbuttontype.h \
+    view/clfixedqueue.h \
     view/clview.h \
     view/clqmlconnector.h \
     view/clviewmodel.h \

--- a/1_CALC_MVC/controller/cloverlordcontroller.cpp
+++ b/1_CALC_MVC/controller/cloverlordcontroller.cpp
@@ -19,7 +19,9 @@ void CLOverlordController::processOperation()
 {
     if(this->operation)
     {
-        this->operation->setDelta(this->view->getModelText());
+        if(this->view->getLastPress() == CLButtonType::Number || this->view->getLastPress() == CLButtonType::Operation)
+            this->operation->setDelta(this->view->getModelText());
+
         this->operation->execute();
         this->view->setModelText(this->operation->getResult());
 

--- a/1_CALC_MVC/controller/cloverlordcontroller.cpp
+++ b/1_CALC_MVC/controller/cloverlordcontroller.cpp
@@ -11,7 +11,7 @@ CLOverlordController::CLOverlordController(QObject* root, std::shared_ptr<QQuick
 void CLOverlordController::createOperation(const QString& operation)
 {
     this->operation = this->factory->create(operation);
-    this->operation->setFirst(this->view->getModelText());
+    this->operation->setResult(this->view->getModelText());
 
     this->view->clearLater();
 }
@@ -20,7 +20,7 @@ void CLOverlordController::processOperation()
 {
     if(this->operation)
     {
-        this->operation->setSecond(this->view->getModelText());
+        this->operation->setDelta(this->view->getModelText());
         this->operation->execute();
         this->view->setModelText(this->operation->getResult());
 

--- a/1_CALC_MVC/controller/cloverlordcontroller.cpp
+++ b/1_CALC_MVC/controller/cloverlordcontroller.cpp
@@ -5,7 +5,6 @@ CLOverlordController::CLOverlordController(QObject* root, std::shared_ptr<QQuick
 {
     QObject::connect(this->view.get(), &CLView::operationClicked, this, &CLOverlordController::createOperation);
     QObject::connect(this->view.get(), &CLView::equalsSignClicked, this, &CLOverlordController::processOperation);
-
 }
 
 void CLOverlordController::createOperation(const QString& operation)

--- a/1_CALC_MVC/model/clmodel.cpp
+++ b/1_CALC_MVC/model/clmodel.cpp
@@ -2,37 +2,26 @@
 
 CLModel::CLModel()
 {
-    this->data.setFirst(0);
-    this->data.setSecond(0);
-    this->data.setResult(0);
+    this->data.delta = 0;
+    this->data.result = 0;
 }
 
-double CLModel::getFirst()
+double CLModel::getDelta()
 {
-    return this->data.getFirst();
+    return this->data.delta;
 }
 
-void CLModel::setFirst(double newFirst)
+void CLModel::setDelta(double newDelta)
 {
-    this->data.setFirst(newFirst);
-}
-
-double CLModel::getSecond()
-{
-    return this->data.getSecond();
-}
-
-void CLModel::setSecond(double newSecond)
-{
-    this->data.setSecond(newSecond);
-}
-
-void CLModel::setResult(double newResult)
-{
-    this->data.setResult(newResult);
+    this->data.delta = newDelta;
 }
 
 double CLModel::getResult()
 {
-    return this->data.getResult();
+    return this->data.result;
+}
+
+void CLModel::setResult(double newResult)
+{
+    this->data.result = newResult;
 }

--- a/1_CALC_MVC/model/clmodel.h
+++ b/1_CALC_MVC/model/clmodel.h
@@ -9,10 +9,8 @@ class CLModel
   public:
     CLModel();
 
-    double getFirst();
-    void setFirst(double newFirst);
-    double getSecond();
-    void setSecond(double newSecond);
+    double getDelta();
+    void setDelta(double newDelta);
     void setResult(double newResult);
     double getResult();
 

--- a/1_CALC_MVC/model/clmodeldata.cpp
+++ b/1_CALC_MVC/model/clmodeldata.cpp
@@ -1,37 +1,7 @@
 #include "clmodeldata.h"
 
 CLModelData::CLModelData()
-    : first(0), second(0), result(0)
+    : result(0), delta(0)
 {
 
-}
-
-void CLModelData::setFirst(double newFirst)
-{
-    this->first = newFirst;
-}
-
-double CLModelData::getFirst()
-{
-    return this->first;
-}
-
-void CLModelData::setSecond(double newSecond)
-{
-    this->second = newSecond;
-}
-
-double CLModelData::getSecond()
-{
-    return this->second;
-}
-
-void CLModelData::setResult(double newResult)
-{
-    this->result = newResult;
-}
-
-double CLModelData::getResult()
-{
-    return this->result;
 }

--- a/1_CALC_MVC/model/clmodeldata.h
+++ b/1_CALC_MVC/model/clmodeldata.h
@@ -1,22 +1,12 @@
 #ifndef CLMODELDATA_H
 #define CLMODELDATA_H
 
-class CLModelData
+struct CLModelData
 {
-  public:
     CLModelData();
 
-    void setFirst(double newFirst);
-    double getFirst();
-    void setSecond(double newSecond);
-    double getSecond();
-    void setResult(double newResult);
-    double getResult();
-
-  private:
-    double first;
-    double second;
     double result;
+    double delta;
 };
 
 #endif // CLMODELDATA_H

--- a/1_CALC_MVC/model/cloperations.cpp
+++ b/1_CALC_MVC/model/cloperations.cpp
@@ -11,14 +11,14 @@ QString CLIArithmeticOperation::getResult()
     return QString::number(this->model->getResult(), 'g', 22);
 }
 
-void CLIArithmeticOperation::setFirst(const QString& first)
+void CLIArithmeticOperation::setResult(const QString& result)
 {
-    this->model->setFirst(first.toDouble());
+    this->model->setResult(result.toDouble());
 }
 
-void CLIArithmeticOperation::setSecond(const QString& second)
+void CLIArithmeticOperation::setDelta(const QString& delta)
 {
-    this->model->setSecond(second.toDouble());
+    this->model->setDelta(delta.toDouble());
 }
 
 CLOAddition::CLOAddition(std::shared_ptr<CLModel> newModel) : CLIArithmeticOperation(newModel)
@@ -43,20 +43,20 @@ CLODivision::CLODivision(std::shared_ptr<CLModel> newModel) : CLIArithmeticOpera
 
 void CLOAddition::execute()
 {
-    this->model->setResult(this->model->getFirst() + this->model->getSecond());
+    this->model->setResult(this->model->getResult() + this->model->getDelta());
 }
 
 void CLOSubstraction::execute()
 {
-    this->model->setResult(this->model->getFirst() - this->model->getSecond());
+    this->model->setResult(this->model->getResult() - this->model->getDelta());
 }
 
 void CLOMultiplication::execute()
 {
-    this->model->setResult(this->model->getFirst() * this->model->getSecond());
+    this->model->setResult(this->model->getResult() * this->model->getDelta());
 }
 
 void CLODivision::execute()
 {
-    this->model->setResult(this->model->getFirst() / this->model->getSecond());
+    this->model->setResult(this->model->getResult() / this->model->getDelta());
 }

--- a/1_CALC_MVC/model/cloperations.h
+++ b/1_CALC_MVC/model/cloperations.h
@@ -12,8 +12,8 @@ class CLIArithmeticOperation
     virtual ~CLIArithmeticOperation() = default;
 
     QString getResult();
-    void setFirst(const QString& first);
-    void setSecond(const QString& second);
+    void setResult(const QString& result);
+    void setDelta(const QString& delta);
     virtual void execute() = 0;
   protected:
     std::shared_ptr<CLModel> model;

--- a/1_CALC_MVC/view/clbuttontype.h
+++ b/1_CALC_MVC/view/clbuttontype.h
@@ -1,0 +1,12 @@
+#ifndef CLBUTTONTYPE_H
+#define CLBUTTONTYPE_H
+
+enum class CLButtonType
+{
+    Nothing,
+    Number,
+    Operation,
+    Equals
+};
+
+#endif // CLBUTTONTYPE_H

--- a/1_CALC_MVC/view/clfixedqueue.h
+++ b/1_CALC_MVC/view/clfixedqueue.h
@@ -1,0 +1,21 @@
+#ifndef CLFIXEDQUEUE_H
+#define CLFIXEDQUEUE_H
+
+#include <queue>
+#include <deque>
+#include <iostream>
+
+template <typename T, int MaxLen, typename Container=std::deque<T>>
+class CLFixedQueue : public std::queue<T, Container> {
+public:
+    void push(const T& value)
+    {
+        if (this->size() == MaxLen)
+        {
+           this->c.pop_front();
+        }
+        std::queue<T, Container>::push(value);
+    }
+};
+
+#endif // CLFIXEDQUEUE_H

--- a/1_CALC_MVC/view/clview.cpp
+++ b/1_CALC_MVC/view/clview.cpp
@@ -6,13 +6,41 @@ CLView::CLView(QObject *root, std::shared_ptr<QQuickView> mainView): QObject(roo
    this->model = std::make_shared<CLViewModel>(root);
    this->qmlConnector = std::make_unique<CLQmlConnector>(root, mainView);
 
+   this->lastPress.push(CLButtonType::Nothing);
+   this->lastPress.push(CLButtonType::Nothing);
+
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::changeModelTextForDelta, this, &CLView::changeModelTextForDelta);
    QObject::connect(this->model.get(), &CLViewModel::displayValueChanged, this, &CLView::setQmlText);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::resetQmlMainDisplay, this, &CLView::resetQmlDisplay);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::eraseOne, this, &CLView::eraseOne);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::operationClicked, this, &CLView::operationClicked);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::equalsSignClicked, this, &CLView::equalsSignClicked);
+
+   QObject::connect(this, &CLView::lastPressChanged, this, &CLView::setLastPress);
+   QObject::connect(this, &CLView::equalsSignClicked, this, &CLView::setLastPressToEquals);
+   QObject::connect(this, &CLView::operationClicked, this, &CLView::setLastPressToOperation);
 }
+
+void CLView::setLastPress(const CLButtonType& lastPress)
+{
+    this->lastPress.push(lastPress);
+}
+
+const CLButtonType& CLView::getLastPress()
+{
+    return this->lastPress.front();
+}
+
+void CLView::setLastPressToEquals()
+{
+    emit this->lastPressChanged(CLButtonType::Equals);
+}
+
+void CLView::setLastPressToOperation()
+{
+    emit this->lastPressChanged(CLButtonType::Operation);
+}
+
 
 /**
  * @brief CLView::changeModelTextForDelta(const QString&) changes display text according to the number pressed.
@@ -27,6 +55,8 @@ void CLView::changeModelTextForDelta(const QString &deltaText)
       this->model->setDisplayValue( ((this->model->getDisplayValue() == "0") || this->clearNext) ? deltaText : this->model->getDisplayValue() + deltaText);
 
     this->clearNext = false;
+
+    emit this->lastPressChanged(CLButtonType::Number);
 }
 
 void CLView::setQmlText(const QString& newText)

--- a/1_CALC_MVC/view/clview.h
+++ b/1_CALC_MVC/view/clview.h
@@ -5,6 +5,8 @@
 #include "view/clviewmodel.h"
 #include "view/clqmlconnector.h"
 #include <memory>
+#include "view/clbuttontype.h"
+#include "view/clfixedqueue.h"
 
 class CLView : public QObject
 {
@@ -13,15 +15,22 @@ public:
     CLView(QObject* root, std::shared_ptr<QQuickView> mainView);
     QString getModelText();
     void clearLater();
+    const CLButtonType& getLastPress();
 signals:
     void operationClicked(const QString& operation);
     void equalsSignClicked();
+    void lastPressChanged(const CLButtonType& lastPress);
 public slots:
     void setModelText(const QString& newText);
+
+    void setLastPress(const CLButtonType& lastPress);
+    void setLastPressToEquals();
+    void setLastPressToOperation();
 private:
     std::shared_ptr<CLViewModel> model;
     std::unique_ptr<CLQmlConnector> qmlConnector;
     bool clearNext;
+    CLFixedQueue<CLButtonType, 2> lastPress;
 private slots:
     void setQmlText(const QString& newText);
     void changeModelTextForDelta(const QString& deltaText);


### PR DESCRIPTION
- On equals sign button press, the application had previously behaved incorrectly. It had performed the last operation on the accumulator result instead of the second operand. This has been fixed: now it performs the last operation on the second operand instead.

- Refactored the "first operand - second operand - result" model into just "result - delta" as I don't need to store the first operand, I need to just always perform the last operation and that's it.

- Refactored the application into tracking the previous button press to easily distinguish what each operation needs to do when it is called.

- Used the implemented 2-element button press queue to fix equals sign sequencing.