### PR TITLE
3-bug: operation sequencing is broken

### DIFF
--- a/1_CALC_MVC/controller/cloverlordcontroller.cpp
+++ b/1_CALC_MVC/controller/cloverlordcontroller.cpp
@@ -9,6 +9,9 @@ CLOverlordController::CLOverlordController(QObject* root, std::shared_ptr<QQuick
 
 void CLOverlordController::createOperation(const QString& operation)
 {
+    if(this->operation && this->view->getLastPress() == CLButtonType::Number)
+        this->processOperation();
+
     this->operation = this->factory->create(operation);
     this->operation->setResult(this->view->getModelText());
 


### PR DESCRIPTION
Operation sequencing was not compliant with the standard MS Windows calculator:
- On operation press, the application has to:
  a. If there is something to calculate (the current operation is set and the last button press was a number), calculate the operation first and only THEN set the new operation.
  b. If there is nothing to calculate (the last button press wasn't number or the operation hasn't been set yet), just set the new operation as usual.

Described behavior has been implemented in this pull request.