### PR TITLE
4-bug: clear entry button naming is incorrect

### DIFF
--- a/1_CALC_MVC/CalcForm.qml
+++ b/1_CALC_MVC/CalcForm.qml
@@ -18,7 +18,7 @@ Item {
     property alias mainDisplayLength: teMainNumericDisplay.maximumLength
     signal numberClicked(string number);
     signal offClicked();
-    signal cancelClicked();
+    signal clearEntryClicked();
     signal eraseOneClicked();
     signal operationClicked(string operation);
     signal equalsSignClicked();
@@ -63,16 +63,16 @@ Item {
         }
 
         Button {
-            id: btCancelOperand
+            id: btClearEntry
             y: 0
             Layout.row: 1
             Layout.column: 0
             width: height
-            text: qsTr("C")
+            text: qsTr("CE")
             font.pointSize: 24
             highlighted: false
 
-            onClicked: cancelClicked();
+            onClicked: clearEntryClicked();
 
         }
 

--- a/1_CALC_MVC/view/clqmlconnector.cpp
+++ b/1_CALC_MVC/view/clqmlconnector.cpp
@@ -12,11 +12,10 @@ CLQmlConnector::CLQmlConnector(QObject *root, std::shared_ptr<QQuickView> mainVi
 
     QObject::connect(this->object, SIGNAL(numberClicked(const QString&)), this, SIGNAL(changeModelTextForDelta(const QString&)));
     QObject::connect(this->object, SIGNAL(offClicked()), qApp, SLOT(quit()));
-    QObject::connect(this->object, SIGNAL(cancelClicked()), this, SIGNAL(resetQmlMainDisplay()));
+    QObject::connect(this->object, SIGNAL(clearEntryClicked()), this, SIGNAL(clearEntryClicked()));
     QObject::connect(this->object, SIGNAL(eraseOneClicked()), this, SIGNAL(eraseOne()));
     QObject::connect(this->object, SIGNAL(operationClicked(const QString&)), this, SIGNAL(operationClicked(const QString&)));
     QObject::connect(this->object, SIGNAL(equalsSignClicked()), this, SIGNAL(equalsSignClicked()));
-
 }
 
 void CLQmlConnector::setQmlMainDisplayText(const QString& newText)

--- a/1_CALC_MVC/view/clqmlconnector.h
+++ b/1_CALC_MVC/view/clqmlconnector.h
@@ -17,7 +17,7 @@ public:
     int getQmlMainDisplayLength();
 signals:
     void changeModelTextForDelta(const QString& deltaText);
-    void resetQmlMainDisplay();
+    void clearEntryClicked();
     void eraseOne();
     void operationClicked(const QString& operation);
     void equalsSignClicked();

--- a/1_CALC_MVC/view/clview.cpp
+++ b/1_CALC_MVC/view/clview.cpp
@@ -11,7 +11,7 @@ CLView::CLView(QObject *root, std::shared_ptr<QQuickView> mainView): QObject(roo
 
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::changeModelTextForDelta, this, &CLView::changeModelTextForDelta);
    QObject::connect(this->model.get(), &CLViewModel::displayValueChanged, this, &CLView::setQmlText);
-   QObject::connect(this->qmlConnector.get(), &CLQmlConnector::resetQmlMainDisplay, this, &CLView::resetQmlDisplay);
+   QObject::connect(this->qmlConnector.get(), &CLQmlConnector::clearEntryClicked, this, &CLView::clearEntry);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::eraseOne, this, &CLView::eraseOne);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::operationClicked, this, &CLView::operationClicked);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::equalsSignClicked, this, &CLView::equalsSignClicked);
@@ -64,7 +64,7 @@ void CLView::setQmlText(const QString& newText)
     this->qmlConnector->setQmlMainDisplayText(newText);
 }
 
-void CLView::resetQmlDisplay()
+void CLView::clearEntry()
 {
     this->model->setDisplayValue("0");
 }

--- a/1_CALC_MVC/view/clview.h
+++ b/1_CALC_MVC/view/clview.h
@@ -34,7 +34,7 @@ private:
 private slots:
     void setQmlText(const QString& newText);
     void changeModelTextForDelta(const QString& deltaText);
-    void resetQmlDisplay();
+    void clearEntry();
     void eraseOne();
 };
 


### PR DESCRIPTION
- Clear Entry button naming was incorrect and inconsistent. It was called Cancel Operand, Cancel, Reset QML Display etc. It has to be uniformly called Clear Entry everywhere, according to the standard MS Calculator.