### PR TITLE
5-bug: clear entry button sequencing is not in compliance with the MS calculator

### DIFF
--- a/1_CALC_MVC/controller/cloverlordcontroller.cpp
+++ b/1_CALC_MVC/controller/cloverlordcontroller.cpp
@@ -36,4 +36,7 @@ void CLOverlordController::processOperation()
 void CLOverlordController::clearEntry()
 {
     this->view->setModelText("0");
+
+    if(this->view->getLastPress() == CLButtonType::Equals)
+        this->operation->setResult("0");
 }

--- a/1_CALC_MVC/controller/cloverlordcontroller.cpp
+++ b/1_CALC_MVC/controller/cloverlordcontroller.cpp
@@ -5,6 +5,7 @@ CLOverlordController::CLOverlordController(QObject* root, std::shared_ptr<QQuick
 {
     QObject::connect(this->view.get(), &CLView::operationClicked, this, &CLOverlordController::createOperation);
     QObject::connect(this->view.get(), &CLView::equalsSignClicked, this, &CLOverlordController::processOperation);
+    QObject::connect(this->view.get(), &CLView::clearEntryClicked, this, &CLOverlordController::clearEntry);
 }
 
 void CLOverlordController::createOperation(const QString& operation)
@@ -30,4 +31,9 @@ void CLOverlordController::processOperation()
 
         this->view->clearLater();
     }
+}
+
+void CLOverlordController::clearEntry()
+{
+    this->view->setModelText("0");
 }

--- a/1_CALC_MVC/controller/cloverlordcontroller.cpp
+++ b/1_CALC_MVC/controller/cloverlordcontroller.cpp
@@ -10,7 +10,7 @@ CLOverlordController::CLOverlordController(QObject* root, std::shared_ptr<QQuick
 
 void CLOverlordController::createOperation(const QString& operation)
 {
-    if(this->operation && this->view->getLastPress() == CLButtonType::Number)
+    if(this->operation && this->view->getPreviousPress() == CLButtonType::Number)
         this->processOperation();
 
     this->operation = this->factory->create(operation);
@@ -23,7 +23,7 @@ void CLOverlordController::processOperation()
 {
     if(this->operation)
     {
-        if(this->view->getLastPress() == CLButtonType::Number || this->view->getLastPress() == CLButtonType::Operation)
+        if(this->view->getPreviousPress() == CLButtonType::Number || this->view->getPreviousPress() == CLButtonType::Operation)
             this->operation->setDelta(this->view->getModelText());
 
         this->operation->execute();

--- a/1_CALC_MVC/controller/cloverlordcontroller.h
+++ b/1_CALC_MVC/controller/cloverlordcontroller.h
@@ -16,6 +16,7 @@ class CLOverlordController: public QObject
   private slots:
     void createOperation(const QString& operation);
     void processOperation();
+    void clearEntry();
 
   private:
     std::shared_ptr<CLIArithmeticOperation> operation;

--- a/1_CALC_MVC/view/clview.cpp
+++ b/1_CALC_MVC/view/clview.cpp
@@ -28,6 +28,11 @@ void CLView::setLastPress(const CLButtonType& lastPress)
 
 const CLButtonType& CLView::getLastPress()
 {
+    return this->lastPress.back();
+}
+
+const CLButtonType& CLView::getPreviousPress()
+{
     return this->lastPress.front();
 }
 

--- a/1_CALC_MVC/view/clview.cpp
+++ b/1_CALC_MVC/view/clview.cpp
@@ -11,7 +11,7 @@ CLView::CLView(QObject *root, std::shared_ptr<QQuickView> mainView): QObject(roo
 
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::changeModelTextForDelta, this, &CLView::changeModelTextForDelta);
    QObject::connect(this->model.get(), &CLViewModel::displayValueChanged, this, &CLView::setQmlText);
-   QObject::connect(this->qmlConnector.get(), &CLQmlConnector::clearEntryClicked, this, &CLView::clearEntry);
+   QObject::connect(this->qmlConnector.get(), &CLQmlConnector::clearEntryClicked, this, &CLView::clearEntryClicked);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::eraseOne, this, &CLView::eraseOne);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::operationClicked, this, &CLView::operationClicked);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::equalsSignClicked, this, &CLView::equalsSignClicked);
@@ -62,11 +62,6 @@ void CLView::changeModelTextForDelta(const QString &deltaText)
 void CLView::setQmlText(const QString& newText)
 {
     this->qmlConnector->setQmlMainDisplayText(newText);
-}
-
-void CLView::clearEntry()
-{
-    this->model->setDisplayValue("0");
 }
 
 void CLView::eraseOne()

--- a/1_CALC_MVC/view/clview.h
+++ b/1_CALC_MVC/view/clview.h
@@ -15,7 +15,9 @@ public:
     CLView(QObject* root, std::shared_ptr<QQuickView> mainView);
     QString getModelText();
     void clearLater();
+
     const CLButtonType& getLastPress();
+    const CLButtonType& getPreviousPress();
 signals:
     void operationClicked(const QString& operation);
     void equalsSignClicked();

--- a/1_CALC_MVC/view/clview.h
+++ b/1_CALC_MVC/view/clview.h
@@ -19,6 +19,7 @@ public:
 signals:
     void operationClicked(const QString& operation);
     void equalsSignClicked();
+    void clearEntryClicked();
     void lastPressChanged(const CLButtonType& lastPress);
 public slots:
     void setModelText(const QString& newText);
@@ -34,7 +35,6 @@ private:
 private slots:
     void setQmlText(const QString& newText);
     void changeModelTextForDelta(const QString& deltaText);
-    void clearEntry();
     void eraseOne();
 };
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ increment the 1st number.
   - The "CA" button should become the "C" button instead, and it should be implemented. It clears everything;
   - Introduce the floating point logic;
   - Implement keyboard key bindings for all the buttons.
+  - **POSSIBLE BUG:** When you press CE and then /, the MS calculator throws the "cannot divide by zero" exception. This calculator currently just ignores it and continues the expression calculation without it. Have to find why the behaviors are different.
 
 ## 2 - Effective Modern Cpp
 This is a project created for the purpose of learning stuff from said book. Try to create a small program for each item to use it the way the book


### PR DESCRIPTION
- The CE button should clear the display on press (already does that), but it should also clear the base result and only leave delta and the operation if pressed after the =. This pull request fixed that.