### PR TITLE
6-feature: the CA button implementation

### DIFF
--- a/1_CALC_MVC/CalcForm.qml
+++ b/1_CALC_MVC/CalcForm.qml
@@ -19,6 +19,7 @@ Item {
     signal numberClicked(string number);
     signal offClicked();
     signal clearEntryClicked();
+    signal clearAllClicked();
     signal eraseOneClicked();
     signal operationClicked(string operation);
     signal equalsSignClicked();
@@ -77,7 +78,7 @@ Item {
         }
 
         Button {
-            id: btCancelAll
+            id: btClearAll
             y: 0
             Layout.row: 1
             Layout.column: 1
@@ -85,6 +86,8 @@ Item {
             text: qsTr("CA")
             font.pointSize: 24
             highlighted: false
+
+            onClicked: clearAllClicked();
 
         }
 

--- a/1_CALC_MVC/controller/cloverlordcontroller.cpp
+++ b/1_CALC_MVC/controller/cloverlordcontroller.cpp
@@ -6,6 +6,7 @@ CLOverlordController::CLOverlordController(QObject* root, std::shared_ptr<QQuick
     QObject::connect(this->view.get(), &CLView::operationClicked, this, &CLOverlordController::createOperation);
     QObject::connect(this->view.get(), &CLView::equalsSignClicked, this, &CLOverlordController::processOperation);
     QObject::connect(this->view.get(), &CLView::clearEntryClicked, this, &CLOverlordController::clearEntry);
+    QObject::connect(this->view.get(), &CLView::clearAllClicked, this, &CLOverlordController::clearAll);
 }
 
 void CLOverlordController::createOperation(const QString& operation)
@@ -39,4 +40,11 @@ void CLOverlordController::clearEntry()
 
     if(this->view->getLastPress() == CLButtonType::Equals)
         this->operation->setResult("0");
+}
+
+void CLOverlordController::clearAll()
+{
+    this->operation.reset();
+    this->view->setModelText("0");
+    this->view->setLastPress(CLButtonType::Nothing);
 }

--- a/1_CALC_MVC/controller/cloverlordcontroller.h
+++ b/1_CALC_MVC/controller/cloverlordcontroller.h
@@ -17,6 +17,7 @@ class CLOverlordController: public QObject
     void createOperation(const QString& operation);
     void processOperation();
     void clearEntry();
+    void clearAll();
 
   private:
     std::shared_ptr<CLIArithmeticOperation> operation;

--- a/1_CALC_MVC/view/clqmlconnector.cpp
+++ b/1_CALC_MVC/view/clqmlconnector.cpp
@@ -13,6 +13,7 @@ CLQmlConnector::CLQmlConnector(QObject *root, std::shared_ptr<QQuickView> mainVi
     QObject::connect(this->object, SIGNAL(numberClicked(const QString&)), this, SIGNAL(changeModelTextForDelta(const QString&)));
     QObject::connect(this->object, SIGNAL(offClicked()), qApp, SLOT(quit()));
     QObject::connect(this->object, SIGNAL(clearEntryClicked()), this, SIGNAL(clearEntryClicked()));
+    QObject::connect(this->object, SIGNAL(clearAllClicked()), this, SIGNAL(clearAllClicked()));
     QObject::connect(this->object, SIGNAL(eraseOneClicked()), this, SIGNAL(eraseOne()));
     QObject::connect(this->object, SIGNAL(operationClicked(const QString&)), this, SIGNAL(operationClicked(const QString&)));
     QObject::connect(this->object, SIGNAL(equalsSignClicked()), this, SIGNAL(equalsSignClicked()));

--- a/1_CALC_MVC/view/clqmlconnector.h
+++ b/1_CALC_MVC/view/clqmlconnector.h
@@ -18,6 +18,7 @@ public:
 signals:
     void changeModelTextForDelta(const QString& deltaText);
     void clearEntryClicked();
+    void clearAllClicked();
     void eraseOne();
     void operationClicked(const QString& operation);
     void equalsSignClicked();

--- a/1_CALC_MVC/view/clview.cpp
+++ b/1_CALC_MVC/view/clview.cpp
@@ -12,6 +12,7 @@ CLView::CLView(QObject *root, std::shared_ptr<QQuickView> mainView): QObject(roo
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::changeModelTextForDelta, this, &CLView::changeModelTextForDelta);
    QObject::connect(this->model.get(), &CLViewModel::displayValueChanged, this, &CLView::setQmlText);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::clearEntryClicked, this, &CLView::clearEntryClicked);
+   QObject::connect(this->qmlConnector.get(), &CLQmlConnector::clearAllClicked, this, &CLView::clearAllClicked);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::eraseOne, this, &CLView::eraseOne);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::operationClicked, this, &CLView::operationClicked);
    QObject::connect(this->qmlConnector.get(), &CLQmlConnector::equalsSignClicked, this, &CLView::equalsSignClicked);

--- a/1_CALC_MVC/view/clview.h
+++ b/1_CALC_MVC/view/clview.h
@@ -22,6 +22,7 @@ signals:
     void operationClicked(const QString& operation);
     void equalsSignClicked();
     void clearEntryClicked();
+    void clearAllClicked();
     void lastPressChanged(const CLButtonType& lastPress);
 public slots:
     void setModelText(const QString& newText);

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ increment the 1st number.
     a. Always perform the last operation available on the second operand;
   + **(DONE)** Operations buttons work, but one nuance is left:
     a. An operation button should push current input into result if pressed for the second time or more (but only once, after that it's just choosing an operation again);
-  - **(DONE)** The "C" button should become "CE" as its current function is clearing the current input on display, which is done by the "CE" button;
-  - The "CA" button should become the "C" button instead, and it should be implemented. It clears everything;
+  - **(DONE)** The "C" button should become "CE" (Clear Entry) as its current function is clearing the current input on display, which is usually done by the "CE" button;
+  - **(DONE)** The "CA" button (Clear All) should be implemented. It clears everything;
   - Introduce the floating point logic;
   - Implement keyboard key bindings for all the buttons.
   - **POSSIBLE BUG:** When you press CE and then /, the MS calculator throws the "cannot divide by zero" exception. This calculator currently just ignores it and continues the expression calculation without it. Have to find why the behaviors are different.


### PR DESCRIPTION
The CA button (Clear All) should clear all the fields/text in the calculator. This means it should:
- Clear the calculator's text field;
- Clear the current operation completely: the operation itself, the result and the delta.

- Also the README.md should be updated with the indication that the CA button feature is done.