### PR TITLE
10-bug: CALC project: max digit numbers break input sequencing

### DIFF
--- a/1_CALC_MVC/view/clview.cpp
+++ b/1_CALC_MVC/view/clview.cpp
@@ -50,16 +50,18 @@ void CLView::setLastPressToOperation()
 
 
 /**
- * @brief CLView::changeModelTextForDelta(const QString&) changes display text according to the number pressed.
- * The function restricts user input to 13 numbers, becauase maximum display length is 26 (in case of
- * multiplication the number's length may double). Also it appends the string with the number, but
- * if number is 0, it substitutes this 0 with the number instead (to avoid numbers like 038).
- * @param deltaText - the delta (appending number) string that has to be attached to the display.
+ * @brief CLView::changeModelTextForDelta(const QString&) changes display text according to the digit pressed.
+ * The method appends the string with a delta digit, but if the digit is 0, it substitutes this 0 with the digit
+ * button just pressed instead (to avoid numbers like 038).
+ * @param deltaText - the delta string that has to be appended to the displayed number.
  */
 void CLView::changeModelTextForDelta(const QString &deltaText)
 {
-    if( (this->model->getDisplaySize() + deltaText.size()) <= (this->qmlConnector->getQmlMainDisplayLength() / 2))
-      this->model->setDisplayValue( ((this->model->getDisplayValue() == "0") || this->clearNext) ? deltaText : this->model->getDisplayValue() + deltaText);
+    if((this->model->getDisplaySize() + deltaText.size() > qmlConnector->getQmlMainDisplayLength()) &&
+            !this->clearNext)
+        return;
+
+    this->model->setDisplayValue( ((this->model->getDisplayValue() == "0") || this->clearNext) ? deltaText : this->model->getDisplayValue() + deltaText);
 
     this->clearNext = false;
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ increment the 1st number.
     c. '.' pressed after 0 should be '0.', not '.'.
   - **(DONE)** Implement keyboard key bindings for all the buttons.
   - **(NOT REPRODUCIBLE)** When you press CE and then /, the MS calculator throws the "cannot divide by zero" exception. This calculator currently just ignores it and continues the expression calculation without it. Have to find why the behaviors are different. (either this has been fixed impilicitly or this has never been a bug in the first place. Right now this is not reproducible.)
-  - **BUG:** If you input a number of max precision (currently 13/26), the application sequencing breaks. Needs additional investigation;
+  - **(FIXED)** If you input a max digit number (currently 26), the application sequencing breaks. Needs additional investigation;
   - **BUG:** Floating point logic has been implemented, but the precision on the floating point values is wonky. Currently the display shows values with the smallest possible precision, that's why display values are not always displayed with the necessary precision value.
   - **POSSIBLE REFACTOR:** Try to find a way to pack all keyboard bindings for numbers into one entity without code duplication (may not be possible, repeater doesn't work);
   - **REFACTOR:** Pack all operation buttons into one repeater (possibly their shortcuts too);


### PR DESCRIPTION
The max digit bug has been fixed.

The problem turned out to be that the max digit limit check in the changeModelTextForDelta() method did not take the clearNext flag into account. Because of this, the method did not accept input even after the operation button was pressed.

Also, the MAX DIGITS / 2 input limit (currently that would have been 13 characters in one number) has been lifted. The limit is 26 characters now.