### PR TITLE
11-refactor: CALC project: operation buttons don't follow DRY

### DIFF
--- a/1_CALC_MVC/CalcForm.qml
+++ b/1_CALC_MVC/CalcForm.qml
@@ -275,10 +275,6 @@ Item {
 
             onClicked: operationClicked("add");
 
-            Shortcut {
-                sequence: "+"
-                onActivated: operationClicked("add")
-            }
         }
 
         Button
@@ -294,10 +290,6 @@ Item {
 
             onClicked: operationClicked("sub");
 
-            Shortcut {
-                sequence: "-"
-                onActivated: operationClicked("sub")
-            }
         }
 
         Button
@@ -313,10 +305,6 @@ Item {
 
             onClicked: operationClicked("mul");
 
-            Shortcut {
-                sequence: "*"
-                onActivated: operationClicked("mul")
-            }
         }
 
         Button
@@ -332,10 +320,26 @@ Item {
 
             onClicked: operationClicked("div");
 
-            Shortcut {
-                sequence: "/"
-                onActivated: operationClicked("div")
-            }
+        }
+
+        Shortcut {
+            sequence: "+"
+            onActivated: operationClicked("add")
+        }
+
+        Shortcut {
+            sequence: "-"
+            onActivated: operationClicked("sub")
+        }
+
+        Shortcut {
+            sequence: "*"
+            onActivated: operationClicked("mul")
+        }
+
+        Shortcut {
+            sequence: "/"
+            onActivated: operationClicked("div")
         }
     }
 }

--- a/1_CALC_MVC/CalcForm.qml
+++ b/1_CALC_MVC/CalcForm.qml
@@ -273,7 +273,7 @@ Item {
             highlighted: false
             font.pointSize: 24
 
-            onClicked: operationClicked("add");
+            onClicked: operationClicked(text);
 
         }
 
@@ -288,7 +288,7 @@ Item {
             highlighted: false
             font.pointSize: 24
 
-            onClicked: operationClicked("sub");
+            onClicked: operationClicked(text);
 
         }
 
@@ -303,7 +303,7 @@ Item {
             highlighted: false
             font.pointSize: 24
 
-            onClicked: operationClicked("mul");
+            onClicked: operationClicked(text);
 
         }
 
@@ -318,28 +318,28 @@ Item {
             highlighted: false
             font.pointSize: 24
 
-            onClicked: operationClicked("div");
+            onClicked: operationClicked(text);
 
         }
 
         Shortcut {
             sequence: "+"
-            onActivated: operationClicked("add")
+            onActivated: operationClicked(sequence)
         }
 
         Shortcut {
             sequence: "-"
-            onActivated: operationClicked("sub")
+            onActivated: operationClicked(sequence)
         }
 
         Shortcut {
             sequence: "*"
-            onActivated: operationClicked("mul")
+            onActivated: operationClicked(sequence)
         }
 
         Shortcut {
             sequence: "/"
-            onActivated: operationClicked("div")
+            onActivated: operationClicked(sequence)
         }
     }
 }

--- a/1_CALC_MVC/CalcForm.qml
+++ b/1_CALC_MVC/CalcForm.qml
@@ -35,6 +35,12 @@ Item {
         teMainNumericDisplay.setText(newText);
     }
 
+    function getOperation(index)
+    {
+        var op = ["+", "-", "*", "/"];
+        return op[index];
+    }
+
     Shortcut {
         sequence: "0"
         onActivated: numberClicked("0")
@@ -262,84 +268,26 @@ Item {
             }
         }
 
-        Button
-        {
-            id: btOperationPlus
-            width: height
-            Layout.row: 2
-            Layout.column: 3
+        Repeater {
+            model: 4
 
-            text: qsTr("+")
-            highlighted: false
-            font.pointSize: 24
+            Button {
+                width: height
+                Layout.row: 2 + index
+                Layout.column: 3
 
-            onClicked: operationClicked(text);
+                text: getOperation(index)
+                highlighted: false
+                font.pointSize: 24
 
+                onClicked: operationClicked(getOperation(index))
+
+                Shortcut {
+                    sequence: getOperation(index)
+                    onActivated: operationClicked(sequence)
+                }
+            }
         }
 
-        Button
-        {
-            id: btOperationMinus
-            width: height
-            Layout.row: 3
-            Layout.column: 3
-
-            text: qsTr("-")
-            highlighted: false
-            font.pointSize: 24
-
-            onClicked: operationClicked(text);
-
-        }
-
-        Button
-        {
-            id: btOperationMultiply
-            width: height
-            Layout.row: 4
-            Layout.column: 3
-
-            text: qsTr("*")
-            highlighted: false
-            font.pointSize: 24
-
-            onClicked: operationClicked(text);
-
-        }
-
-        Button
-        {
-            id: btOperationDivide
-            width: height
-            Layout.row: 5
-            Layout.column: 3
-
-            text: qsTr("/")
-            highlighted: false
-            font.pointSize: 24
-
-            onClicked: operationClicked(text);
-
-        }
-
-        Shortcut {
-            sequence: "+"
-            onActivated: operationClicked(sequence)
-        }
-
-        Shortcut {
-            sequence: "-"
-            onActivated: operationClicked(sequence)
-        }
-
-        Shortcut {
-            sequence: "*"
-            onActivated: operationClicked(sequence)
-        }
-
-        Shortcut {
-            sequence: "/"
-            onActivated: operationClicked(sequence)
-        }
     }
 }

--- a/1_CALC_MVC/model/cloperationfactory.cpp
+++ b/1_CALC_MVC/model/cloperationfactory.cpp
@@ -1,10 +1,10 @@
 #include "cloperationfactory.h"
 
 
-CLOperationFactory::CLOperationFactory(std::shared_ptr<CLModel> model): model(model), functions {{"add", &CLOperationFactory::createAdd},
-                                                                                                 {"sub", &CLOperationFactory::createSub},
-                                                                                                 {"mul", &CLOperationFactory::createMul},
-                                                                                                 {"div", &CLOperationFactory::createDiv}}
+CLOperationFactory::CLOperationFactory(std::shared_ptr<CLModel> model): model(model), functions {{"+", &CLOperationFactory::createAdd},
+                                                                                                 {"-", &CLOperationFactory::createSub},
+                                                                                                 {"*", &CLOperationFactory::createMul},
+                                                                                                 {"/", &CLOperationFactory::createDiv}}
 {
 
 }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ increment the 1st number.
   - **(FIXED)** If you input a max digit number (currently 26), the application sequencing breaks. Needs additional investigation;
   - **BUG:** Floating point logic has been implemented, but the precision on the floating point values is wonky. Currently the display shows values with the smallest possible precision, that's why display values are not always displayed with the necessary precision value.
   - **POSSIBLE REFACTOR:** Try to find a way to pack all keyboard bindings for numbers into one entity without code duplication (may not be possible, repeater doesn't work);
-  - **REFACTOR:** Pack all operation buttons into one repeater (possibly their shortcuts too);
+  - **(REFACTORED)** Pack all operation buttons into one repeater (and their shortcuts too);
   - Add labels/tips with notifications for upper line control button shortcuts.
   - **REFACTOR:** Prettify the code. Currently only includes the most obvious refactors like the QObject compiler warning and the above-mentioned QML refactors. Also the formatting of the curly braces in the QML file is inconsistent;
   - **ANALYSIS:** Analyze what else can be refactored codewise.


### PR DESCRIPTION
The problem in this refactoring effort is that the operation buttons on the .qml form are basically the same code repeated 4 times. What's even worse, keyboard shortcuts are four MORE pieces of the same code repeated four times. With that said, using the QML Repeater type, it's possible to pack all of those into two pieces of code, one Button type and one nested Shortcut type instead of 4 + 4 as it is now.

This pull request fixes that problem.