### PR TITLE
12-bug: CALC project: pack all number button keyboard shortcuts into one entity

### DIFF
--- a/1_CALC_MVC/CalcForm.qml
+++ b/1_CALC_MVC/CalcForm.qml
@@ -41,56 +41,6 @@ Item {
         return op[index];
     }
 
-    Shortcut {
-        sequence: "0"
-        onActivated: numberClicked("0")
-    }
-
-    Shortcut {
-        sequence: "1"
-        onActivated: numberClicked("1")
-    }
-
-    Shortcut {
-        sequence: "2"
-        onActivated: numberClicked("2")
-    }
-
-    Shortcut {
-        sequence: "3"
-        onActivated: numberClicked("3")
-    }
-
-    Shortcut {
-        sequence: "4"
-        onActivated: numberClicked("4")
-    }
-
-    Shortcut {
-        sequence: "5"
-        onActivated: numberClicked("5")
-    }
-
-    Shortcut {
-        sequence: "6"
-        onActivated: numberClicked("6")
-    }
-
-    Shortcut {
-        sequence: "7"
-        onActivated: numberClicked("7")
-    }
-
-    Shortcut {
-        sequence: "8"
-        onActivated: numberClicked("8")
-    }
-
-    Shortcut {
-        sequence: "9"
-        onActivated: numberClicked("9")
-    }
-
     GridLayout {
         id: grid
         anchors.fill: parent
@@ -210,6 +160,11 @@ Item {
                 onClicked:
                 {
                     numberClicked(text);
+                }
+
+                Shortcut {
+                    sequence: index.toString(10)
+                    onActivated: numberClicked(index.toString(10))
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ increment the 1st number.
   - **(DONE)** Implement keyboard key bindings for all the buttons.
   - **(NOT REPRODUCIBLE)** When you press CE and then /, the MS calculator throws the "cannot divide by zero" exception. This calculator currently just ignores it and continues the expression calculation without it. Have to find why the behaviors are different. (either this has been fixed impilicitly or this has never been a bug in the first place. Right now this is not reproducible.)
   - **(FIXED)** If you input a max digit number (currently 26), the application sequencing breaks. Needs additional investigation;
-  - **(POSSIBLY LEAVE AS IS)** Floating point logic has been implemented, but the precision on the floating point values is wonky. Currently the display shows values with the smallest possible precision, that's why display values are not always displayed with the necessary precision value.
-  - **POSSIBLE REFACTOR:** Try to find a way to pack all keyboard bindings for numbers into one entity without code duplication (may not be possible, repeater doesn't work);
+  - **(POSSIBLY LEAVE AS IS)** Floating point logic has been implemented, but the precision on the floating point values is wonky. Currently the display shows values with the smallest possible precision, that's why display values are not always displayed with the necessary precision value;
+  - **(REFACTORED)** Try to find a way to pack all keyboard bindings for numbers into one entity without code duplication;
   - **(REFACTORED)** Pack all operation buttons into one repeater (and their shortcuts too);
   - Add labels/tips with notifications for upper line control button shortcuts.
+  - **BUG:** When trying to start a new operation after the previous one has just been finished (pressing a number after =), instead of starting a new operation the calculator currently continues calculating the previous operation. Operation sequencing got broken again at some point, needs further investigation;
   - **REFACTOR:** Prettify the code. Currently only includes the most obvious refactors like the QObject compiler warning and the above-mentioned QML refactors. Also the formatting of the curly braces in the QML file is inconsistent;
   - **ANALYSIS:** Analyze what else can be refactored codewise.
 


### PR DESCRIPTION
Currently, keyboard shortcut for every single one of 10 number buttons is a separate entity. This needs to be packed into a single repeater to avoid 50 lines of code duplication.

This pull request refactors the QML form to use a single Repeater instead of 10 Shortcut objects.